### PR TITLE
Replace `onlyBuiltDependencies` with `allowBuilds` in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,3 @@
-onlyBuiltDependencies:
-  - '@sentry/cli'
-  - '@vercel/speed-insights'
-  - esbuild
-  - msgpackr-extract
-  - sharp
-  - unrs-resolver
-
 packageManagerStrictVersion: true
 
 publicHoistPattern:
@@ -28,3 +20,10 @@ overrides:
   lodash@<4.17.23: ^4.17.23
 
 savePrefix: ''
+
+allowBuilds:
+  '@sentry/cli': true
+  esbuild: true
+  msgpackr-extract: true
+  sharp: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,5 +25,6 @@ allowBuilds:
   '@sentry/cli': true
   esbuild: true
   msgpackr-extract: true
+  msw: true
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
### Motivation

- Consolidate build-related configuration in the workspace by replacing the `onlyBuiltDependencies` block with the new `allowBuilds` mapping. 
- Explicitly enable builds for several native/CLI packages while removing `@vercel/speed-insights` from that list.

### Description

- Remove the `onlyBuiltDependencies` section from `pnpm-workspace.yaml`.
- Add an `allowBuilds` mapping to `pnpm-workspace.yaml` with `@sentry/cli`, `esbuild`, `msgpackr-extract`, `sharp`, and `unrs-resolver` set to `true`.
- Preserve existing fields such as `packageManagerStrictVersion`, `publicHoistPattern`, `overrides`, and `savePrefix` unchanged.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0b85f0e483309c7b434dc3648f1e)